### PR TITLE
Fixing NavMenuBar cursor CSS styling

### DIFF
--- a/src/Components/NavigationBar.js
+++ b/src/Components/NavigationBar.js
@@ -36,7 +36,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: "center",
     flexDirection: "column",
     color: "#FFFFFF",
-    marginLeft: 25
+    marginLeft: 15
   },
   navBarMenuText: {
     width: "100%",
@@ -47,7 +47,7 @@ const useStyles = makeStyles(theme => ({
     letterSpacing: "0.03em",
     display: "flex",
     textDecoration: "none",
-    color: "#fff"
+    color: "#fff",
   },
   navBarMenuTextDisabled: {
     width: "100%",
@@ -109,15 +109,14 @@ function NavigationBar() {
             e.status === 'inactive' ? (
              <AlertDialog
               button={
-                <NavLink to={'/arbitrage-dashboard'} className={classes.navBarMenuTextDisabled}>
-                  <div className={classes.navBarMenuTextCursor}>
-                    <div className={classes.navBarMenuButton}>
-                      <img
-                        className={classes.navBarMenuIcon}
-                        src={e.logo}
-                      />
-                      {e.name}
-                    </div>
+                <NavLink activeClassName={classes.navBarMenuTextCursorActive} to={e.link} className={classes.navBarMenuText}>
+                  <div className={classes.navBarMenuButton}>
+                    <img
+                      className={classes.navBarMenuIcon}
+                      style={{ margin: "0px 10px", marginLeft: 50 }}
+                      src={e.logo}
+                    />
+                    {e.name}
                   </div>
                 </NavLink>
               }
@@ -126,8 +125,7 @@ function NavigationBar() {
             />
             ) : (
              <div style={{ all: 'inherit' }}>
-               <NavLink to={e.link} className={classes.navBarMenuText}>
-                <div className={classes.navBarMenuTextCursor}>
+               <NavLink activeClassName={classes.navBarMenuTextCursorActive} to={e.link} className={classes.navBarMenuText}>
                   <div className={classes.navBarMenuButton}>
                     <img
                       className={classes.navBarMenuIcon}
@@ -135,8 +133,6 @@ function NavigationBar() {
                     />
                     {e.name}
                   </div>
-
-                </div>
               </NavLink>
              </div>
             )  


### PR DESCRIPTION
I found out what caused the confusion:
- The tooltip branch and css-fix branch were both based off master. 
- However, they both made changes to the same area of code.

In hindsight, I should have done this:
- Added the reusable tooltip component in it's branch alone. 
- Then fork off that branch or wait for merge to apply the CSS fix.